### PR TITLE
remove addition of item id to title string

### DIFF
--- a/src/Carousel.jsx
+++ b/src/Carousel.jsx
@@ -247,7 +247,7 @@ class Carousel extends Component {
           key={item.id}
           id={item.id}
           itemId={index}
-          title={`${item.title} ${item.id}`}
+          title={item.title}
           caption={item.caption}
           src={item.src}
           transparency={transparency}


### PR DESCRIPTION
As the title states, removes the item id being added to the title string, giving more freedom to the user